### PR TITLE
Added link to package on Chrome Web Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ Chrome extension for hiding Twitch chat by default. Exclusion/inclusion lists su
 ## AUTHORS ##
 
 * Tsuri Kamppuri
+
+## Chrome Web Store ##
+[Twitch Chat Hider on Chrome Web Store](https://chrome.google.com/webstore/detail/twitch-chat-hider/ndcgieheiojhoekkjdcipkbghnmbkiab)


### PR DESCRIPTION
Added link to packaged extension. Googling 'twitch-chat-hider' did not get me to the packaged extension so I assumed it was not on the chrome store. Then after grabbing the extension I realized it was out there just not searchable. So here's a link back to the package to help any other twitch users who come across this useful extension!
